### PR TITLE
Fix setting material on first object

### DIFF
--- a/wavefront-obj.zig
+++ b/wavefront-obj.zig
@@ -252,6 +252,8 @@ pub fn load(
                     _ = objects.pop(); // remove last element, then error
                     return err;
                 };
+
+                currentObject.?.material = try arena.allocator.dupe(u8, line[7..]);
             }
         }
         // parse smoothing groups


### PR DESCRIPTION
When a `usemtl` line is parsed before an object has been started, a new object is created but the declared material is not set on it.